### PR TITLE
Add .well_known Testing

### DIFF
--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -411,14 +411,22 @@ class FpsCheck:
                     json_schema.keys())
                 curr_fps_set = check_sets[primary]
                 for field in schema_fields:
-                    field_sym_difference = set(json_schema[field]) ^ set(
+                    if field == "primary":
+                        if json_schema["primary"] != curr_fps_set.primary:
+                            field_sym_difference = [json_schema["primary"], 
+                            curr_fps_set.primary]
+                        else:
+                            field_sym_difference = []
+                    else:
+                        field_sym_difference = set(json_schema[field]) ^ set(
                         curr_fps_set.relevant_fields_dict[field])
-                    if field == 'ccTLDs':
-                        for aliased_site in json_schema[field]:
-                            field_sym_difference.update(
-                                set(json_schema[field][aliased_site]) ^ set(
-                                curr_fps_set.relevant_fields_dict[field]
-                                [aliased_site]))
+                        if field == 'ccTLDs':
+                            for aliased_site in json_schema[field]:
+                                field_sym_difference.update(
+                                    set(json_schema[field][aliased_site]) ^ 
+                                    set(
+                                    curr_fps_set.relevant_fields_dict[field]
+                                    [aliased_site]))
                     if field_sym_difference:
                         self.error_list.append("The following member(s) of " 
                         + field + " were not present in both the changelist "

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -339,6 +339,18 @@ class FpsCheck:
                             "The provided service site does not have an eTLD " 
                             + "in the Public suffix list: " + service_site)
 
+    def open_and_load_json(self, url):
+        """Calls urlopen and returns json from a site
+
+        Calls urlopena and json.load on a domain. Returns the json object.
+        This functionality is separated out here to make testing easier.
+        
+        Args:
+            url: a domain that we want to load the json from
+        """
+        with urlopen(url) as json_file:
+            return json.load(json_file)
+
     def check_list_sites(self, primary, site_list):
         """Checks that sites in a given list have the correct primary on their 
         well-known page
@@ -357,8 +369,7 @@ class FpsCheck:
         for site in site_list:
             url = site + "/.well-known/first-party-set"
             try:
-                with urlopen(url) as json_file:
-                    json_schema = json.load(json_file)
+                json_schema = self.open_and_load_json(url)
                 if 'primary' not in json_schema.keys():
                     self.error_list.append(
                         "The listed associated site site did not have primary"
@@ -372,8 +383,7 @@ class FpsCheck:
                 self.error_list.append(
                     "Experienced an error when trying to access " + url + "; "
                     + "error was: " + str(inst))
-
-    # For now, the following test is not called
+    
     def find_invalid_well_known(self, check_sets):
         """Checks for and validates well-known pages for FPS sets
 
@@ -396,8 +406,7 @@ class FpsCheck:
             # Read the well-known files and check them against the schema we 
             # have stored
             try:
-                with urlopen(url) as json_file:
-                    json_schema = json.load(json_file)
+                json_schema = self.open_and_load_json(url)
                 schema_fields = set(self.acceptable_fields) & set(
                     json_schema.keys())
                 curr_fps_set = check_sets[primary]

--- a/FpsSet.py
+++ b/FpsSet.py
@@ -34,3 +34,10 @@ class FpsSet:
                                      'primary': primary,
                                      'associatedSites': associated_sites, 
                                      'serviceSites': service_sites}
+    def __eq__(self, obj):
+      if isinstance(obj, FpsSet) and self.primary == obj.primary:
+        if self.ccTLDs == obj.ccTLDs:
+          if self.associated_sites == obj.associated_sites:
+            if self.service_sites == obj.service_sites:
+              return True
+      return False


### PR DESCRIPTION
The find_invalid_well_known function in FpsCheck lacks testing in fps_tests. An additional mock method should be added to fps_tests to mimic the behavior of returning the json contents of a page, so that we can test that FpsCheck properly reads and validates well_known pages. An __eq__ method is also needed in FpsSet. 