### PR TITLE
Rename .well-known/first-party-set to include .json extension

### DIFF
--- a/FPS-Submission_Guidelines.md
+++ b/FPS-Submission_Guidelines.md
@@ -138,8 +138,8 @@ Upon submission of a PR, a series of technical checks will run on GitHub to veri
 		<li>Each domain must satisfy the /.well-known/ metadata requirement:</li>
 		<ul>
 <li>The /.well-known/ metadata requirement demonstrates that the submitter has administrative access to the domains present in the set, since administrative access is required to modify the /.well-known/ file. This will help prevent unauthorized actors from adding domains to a set. </li>
-<li>The primary domain must serve a JSON file at /.well-known/first-party-set. The contents of the file must be identical to the submission. Each member domain must serve a JSON file at /.well-known/first-party-set. The contents of the file must name the primary domain. These files must be maintained for the duration of the domain’s inclusion in the set.</li>
-			<li>Example for  primary.com/.well-known/first-party-set:</li>
+<li>The primary domain must serve a JSON file at /.well-known/first-party-set.json. The contents of the file must be identical to the submission. Each member domain must serve a JSON file at /.well-known/first-party-set.json. The contents of the file must name the primary domain. These files must be maintained for the duration of the domain’s inclusion in the set.</li>
+			<li>Example for  primary.com/.well-known/first-party-set.json:</li>
 		</ul></ul>
 	
 ```json
@@ -161,7 +161,7 @@ Upon submission of a PR, a series of technical checks will run on GitHub to veri
   }
 }
 ```
-The `/.well-known/first-party-set` file for the set primary must follow the schema specified below:
+The `/.well-known/first-party-set.json` file for the set primary must follow the schema specified below:
 ```json
 {
   "type": "object",
@@ -202,13 +202,13 @@ The `/.well-known/first-party-set` file for the set primary must follow the sche
   }
 }
 ```
-Example for associate1.com/.well-known/first-party-set:
+Example for associate1.com/.well-known/first-party-set.json:
 ```json
 {
   "primary":"https://primary.com"
 }
 ```
-The /.well-known/first-party-set file for set members must follow the schema specified below:
+The /.well-known/first-party-set.json file for set members must follow the schema specified below:
 ```json
 {
   "type": "object",

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -323,13 +323,13 @@ class FpsCheck:
             None
         """
         for site in site_list:
-            url = site + "/.well-known/first-party-set"
+            url = site + "/.well-known/first-party-set.json"
             try:
                 json_schema = self.open_and_load_json(url)
                 if 'primary' not in json_schema.keys():
                     self.error_list.append(
                         "The listed associated site site did not have primary"
-                        + " as a key in its .well-known/first-party-set file: "
+                        + " as a key in its .well-known/first-party-set.json file: "
                         + site)
                 elif json_schema['primary'] != primary:
                     self.error_list.append("The listed associated site "
@@ -358,7 +358,7 @@ class FpsCheck:
         # Check the schema to ensure consistency
         for primary in check_sets:
             # First we check the primary sites
-            url = primary + "/.well-known/first-party-set"
+            url = primary + "/.well-known/first-party-set.json"
             # Read the well-known files and check them against the schema we 
             # have stored
             try:
@@ -386,7 +386,7 @@ class FpsCheck:
                     if field_sym_difference:
                         self.error_list.append("The following member(s) of " 
                         + field + " were not present in both the changelist "
-                        + "and .well-known/first-party-sets file: " + 
+                        + "and .well-known/first-party-set.json file: " + 
                         str(sorted(field_sym_difference)))
             except Exception as inst:
                 self.error_list.append(

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -735,39 +735,39 @@ def mock_open_and_load_json(*args, **kwargs):
         def __init__(self, json):
             self.json = json
     
-    if args[0] == 'https://primary1.com/.well-known/first-party-set':
+    if args[0] == 'https://primary1.com/.well-known/first-party-set.json':
         return {
             "primary": "https://primary1.com",
             "associatedSites": ["https://not-in-list.com"]
         }
-    elif args[0] == 'https://expected-associated.com/.well-known/first-party-set':
+    elif args[0] == 'https://expected-associated.com/.well-known/first-party-set.json':
         return {
             "primary": "https://primary1.com"
         }
-    elif args[0] == 'https://primary2.com/.well-known/first-party-set':
+    elif args[0] == 'https://primary2.com/.well-known/first-party-set.json':
         return {
             "primary": "https://wrong-primary.com",
             "associatedSites":["https://associated1.com"]
         }
-    elif args[0] == 'https://associated1.com/.well-known/first-party-set':
+    elif args[0] == 'https://associated1.com/.well-known/first-party-set.json':
         return {
             "primary": "https://primary2.com"
         }
-    elif args[0] == 'https://primary3.com/.well-known/first-party-set':
+    elif args[0] == 'https://primary3.com/.well-known/first-party-set.json':
         return {
             "primary": "https://primary3.com",
             "associatedSites": ["https://associated2.com"]
         }
-    elif args[0] == 'https://associated2.com/.well-known/first-party-set':
+    elif args[0] == 'https://associated2.com/.well-known/first-party-set.json':
         return {
             "primary": "https://wrong-primary.com"
         }
-    elif args[0] == 'https://primary4.com/.well-known/first-party-set':
+    elif args[0] == 'https://primary4.com/.well-known/first-party-set.json':
         return {
             "primary": "https://primary4.com",
             "associatedSites": ["https://associated3.com"]
         }
-    elif args[0] == 'https://associated3.com/.well-known/first-party-set':
+    elif args[0] == 'https://associated3.com/.well-known/first-party-set.json':
         return {
             "primary": "https://primary4.com"
         }
@@ -1070,7 +1070,7 @@ class MockTestsClass(unittest.TestCase):
         self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The following member(s) of " +
         "associatedSites were not present in both the changelist and " + 
-        ".well-known/first-party-sets file: ['https://expected-associated.com'"
+        ".well-known/first-party-set.json file: ['https://expected-associated.com'"
         + ", 'https://not-in-list.com']"])
     
     @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 
@@ -1102,7 +1102,7 @@ class MockTestsClass(unittest.TestCase):
         self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The following member(s) of " +
         "primary were not present in both the changelist and " + 
-        ".well-known/first-party-sets file: ['https://primary2.com'"
+        ".well-known/first-party-set.json file: ['https://primary2.com'"
         + ", 'https://wrong-primary.com']"])
 
     @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 


### PR DESCRIPTION
As noted [here](https://github.com/WICG/first-party-sets/issues/149), certain web hosting plans have difficulty serving JSON files without the .json extension. To make submission easier for these maintainers, the .well-known requirement should be modified to require the JSON be served at /.well-known/first-party-set.json. 