### PR TITLE
Change workflow to run on PR request target

### DIFF
--- a/.github/workflows/fps-submissions-checks.yml
+++ b/.github/workflows/fps-submissions-checks.yml
@@ -12,22 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 name: FPS submission checks
-on: [pull_request]
+on: pull_request_target
 jobs:
   PR-Actions:
     runs-on: ubuntu-latest
     outputs:
       output1: ${{ steps.read_results.outputs.contents }}
     steps:
-      - name: Gather files changed
+      - name: Get the PR version of the files
         uses: actions/checkout@v2
         with:
-          fileOutput: "json"
+          ref: "refs/pull/${{ github.event.number }}/merge"
+          path: "pull-request"
+      - name: Get the version at main
+        uses: actions/checkout@v2
+        with:
+          path: "main"
       - name: Get necessary libraries
         run: pip install publicsuffix2
       - name: Content check
         id: check
-        run: python3 check_sites.py > results.txt
+        run: python3 main/check_sites.py -i pull-request/first_party_sets.JSON > results.txt
       - name: Read the result
         id: read_results
         uses: andstor/file-reader-action@v1
@@ -46,8 +51,9 @@ jobs:
       - name: Write Comment on PR
         uses: mshick/add-pr-comment@v2
         with:   
-          message-path: 
-            "message.txt" 
+          message-path: "message.txt" 
+          allow-repeats: true
+          refresh-message-position: true
       - name: Fail or Succeed
         if: steps.read_results.outputs.contents != 'success'
         uses: actions/github-script@v3

--- a/.github/workflows/fps-submissions-checks.yml
+++ b/.github/workflows/fps-submissions-checks.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip install publicsuffix2
       - name: Content check
         id: check
-        run: python3 main/check_sites.py -i pull-request/first_party_sets.JSON > results.txt
+        run: python3 main/check_sites.py -i pull-request/first_party_sets.JSON --data_directory main > results.txt
       - name: Read the result
         id: read_results
         uses: andstor/file-reader-action@v1
@@ -52,7 +52,6 @@ jobs:
         uses: mshick/add-pr-comment@v2
         with:   
           message-path: "message.txt" 
-          allow-repeats: true
           refresh-message-position: true
       - name: Fail or Succeed
         if: steps.read_results.outputs.contents != 'success'

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -46,7 +46,7 @@ class FpsCheck:
         self.icanns = icanns
         self.error_list = []
 
-    def validate_schema(self):
+    def validate_schema(self, schema_file):
         """Validates the canonical sites list
 
         Calls the validate function from the jsonschema package on the input 
@@ -60,7 +60,7 @@ class FpsCheck:
             jsonschema.exceptions.ValidationError if the schema does not match 
             the format stored in SCHEMA 
         """
-        with open('SCHEMA.json') as f:
+        with open(schema_file) as f:
             SCHEMA = json.loads(f.read())
         validate(self.fps_sites, schema = SCHEMA)
 
@@ -329,8 +329,8 @@ class FpsCheck:
                 if 'primary' not in json_schema.keys():
                     self.error_list.append(
                         "The listed associated site site did not have primary"
-                        + " as a key in its .well-known/first-party-set.json file: "
-                        + site)
+                        + " as a key in its .well-known/first-party-set.json "
+                        "file: " + site)
                 elif json_schema['primary'] != primary:
                     self.error_list.append("The listed associated site "
                     + "did not have " + primary + " listed as its primary: " 

--- a/check_sites.py
+++ b/check_sites.py
@@ -13,19 +13,35 @@
 # limitations under the License.
 from FpsCheck import FpsCheck
 import json
+import getopt
+import sys
 from publicsuffix2 import PublicSuffixList
 
 
 def main():
+    args = sys.argv[1:]
+    inputFile = 'first_party_sets.JSON'
+    inputPrefix = ''
+    opts, _ = getopt.getopt(args, "i:")
+    for opt, arg in opts:
+        if opt == '-i':
+            inputFile = arg
+            inputPrefix='main/'
+
     # Open the canonical sites, and load the json
-    with open('first_party_sets.JSON') as f:
-        fps_sites = json.load(f)
+    with open(inputFile) as f:
+        try:
+            fps_sites = json.load(f)
+        except Exception as inst:
+        # If the file cannot be loaded, we will not run any other checks
+            print(inst)
+            exit()      
 
     # Load the etlds from the public suffix list
-    etlds = PublicSuffixList(psl_file = 'effective_tld_names.dat')
+    etlds = PublicSuffixList(psl_file = inputPrefix+'effective_tld_names.dat')
     # Get all the ICANN domains
     icanns = set()
-    with open('ICANN_domains') as f:
+    with open(inputPrefix+'ICANN_domains') as f:
         for line in f:
             l = line.strip()
             icanns.add(l)
@@ -34,7 +50,7 @@ def main():
     error_texts = []
 
     try:
-        fps_checker.validate_schema()
+        fps_checker.validate_schema(inputPrefix+'SCHEMA.json')
     except Exception as inst:
         # If the schema is invalid, we will not run any other checks
         print(inst)

--- a/check_sites.py
+++ b/check_sites.py
@@ -15,6 +15,7 @@ from FpsCheck import FpsCheck
 import json
 import getopt
 import sys
+import os
 from publicsuffix2 import PublicSuffixList
 
 
@@ -22,11 +23,12 @@ def main():
     args = sys.argv[1:]
     inputFile = 'first_party_sets.JSON'
     inputPrefix = ''
-    opts, _ = getopt.getopt(args, "i:")
+    opts, _ = getopt.getopt(args, "i:", ["data_directory="])
     for opt, arg in opts:
         if opt == '-i':
             inputFile = arg
-            inputPrefix='main/'
+        if opt == '--data_directory':
+            inputPrefix = arg
 
     # Open the canonical sites, and load the json
     with open(inputFile) as f:
@@ -34,14 +36,15 @@ def main():
             fps_sites = json.load(f)
         except Exception as inst:
         # If the file cannot be loaded, we will not run any other checks
-            print(inst)
+            print("There was an error when loading "+ inputFile + 
+                  "\nerror was: " + inst)
             exit()      
 
     # Load the etlds from the public suffix list
-    etlds = PublicSuffixList(psl_file = inputPrefix+'effective_tld_names.dat')
+    etlds = PublicSuffixList(psl_file = os.path.join(inputPrefix,'effective_tld_names.dat'))
     # Get all the ICANN domains
     icanns = set()
-    with open(inputPrefix+'ICANN_domains') as f:
+    with open(os.path.join(inputPrefix,'ICANN_domains')) as f:
         for line in f:
             l = line.strip()
             icanns.add(l)
@@ -50,7 +53,7 @@ def main():
     error_texts = []
 
     try:
-        fps_checker.validate_schema(inputPrefix+'SCHEMA.json')
+        fps_checker.validate_schema(os.path.join(inputPrefix,'SCHEMA.json'))
     except Exception as inst:
         # If the schema is invalid, we will not run any other checks
         print(inst)


### PR DESCRIPTION
Currently, the workflow is set to "on: pull_request" which does not allow the workflow to have write permission to PRs made from forked repos. This issue is preventing comments from appearing on those PRs. Therefore, the workflow should be set to "on: pull_request_target" which will allow the action to have the needed write permissions, and other changes will be made to ensure that other aspects of the workflow remain safe during this process. 