### PR TITLE
policy and code changes for robots check

### DIFF
--- a/FPS-Submission_Guidelines.md
+++ b/FPS-Submission_Guidelines.md
@@ -221,9 +221,10 @@ The /.well-known/first-party-set.json file for set members must follow the schem
 ## Subset-level technical validation ##
 
 Additionally, more granular technical checks will also run on GitHub for service domains and ccTLD variants in the submissions. 
+
 Service Domains must satisfy the following conditions:
 	<ul>
-		<li>Must not have robots.txt, or have a robots.txt with a ["no index"](https://developers.google.com/search/docs/advanced/crawling/block-indexing) header. </li>
+		<li>Must not be crawlable. Service domains must have an X-Robots-Tag containing a 'noindex' or 'none' [value](https://developers.google.com/search/docs/crawling-indexing/robots-meta-tag#directives).</li>
 		<li>Must not have ads.txt.</li>
 <li>Must have a homepage that redirects to a different domain or results in 4xx (client error) or 5xx (server error).</li>
 	</ul>

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -329,8 +329,8 @@ class FpsCheck:
                 if 'primary' not in json_schema.keys():
                     self.error_list.append(
                         "The listed associated site site did not have primary"
-                        + " as a key in its .well-known/first-party-set.json file: "
-                        + site)
+                        + " as a key in its .well-known/first-party-set.json "
+                        + "file: " + site)
                 elif json_schema['primary'] != primary:
                     self.error_list.append("The listed associated site "
                     + "did not have " + primary + " listed as its primary: " 
@@ -480,22 +480,23 @@ class FpsCheck:
             if not check_sets[primary].service_sites:
                 continue
             for service_site in check_sets[primary].service_sites:
-                robot_site = service_site + "/robots.txt"
                 try:
-                    r = requests.get(robot_site, timeout=10)
-                    if r.status_code == 200:
-                        r_service = requests.get(service_site, timeout=10)
-                        if 'X-Robots-Tag' not in r_service.headers:
+                    r_service = requests.get(service_site, timeout=10)
+                    if 'X-Robots-Tag' not in r_service.headers:
+                        self.error_list.append("The service site " + 
+                        service_site + " does not have an X-Robots-Tag in its "
+                         + "header")
+                    else:
+                        robots_tag = r_service.headers['X-Robots-Tag']
+                        if ':' in robots_tag:
                             self.error_list.append("The service site " + 
-                            service_site + " has a robots.txt file, " + 
-                            "but does not have " + 
-                            "X-Robots-Tag in its header")
-                        else:
-                            if r_service.headers['X-Robots-Tag'] != 'noindex':
-                                self.error_list.append(
-                                    "The service site " + service_site + 
-                                    " has a robots.txt file, but does not have"
-                                    + " a no-index tag in its header")
+                                service_site + " contains an 'X-Robots-Tag' " +
+                                "that does not meet the policy requirements")
+                        elif 'none' not in robots_tag and 'noindex' not in robots_tag:
+                                    self.error_list.append("The service site " 
+                                        + service_site + " does not have a " +
+                                        "'noindex' or 'none' tag in its header"
+                                        )
                 except Exception as inst:
                     if exception_retries not in str(inst):
                         if exception_timeout not in str(inst):

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -3,6 +3,7 @@ import sys
 from jsonschema import ValidationError
 from publicsuffix2 import PublicSuffixList
 from unittest import mock
+from requests import structures
 
 sys.path.append('../first-party-sets')
 from FpsSet import FpsSet
@@ -707,7 +708,7 @@ class TestFindInvalidESLDs(unittest.TestCase):
 def mock_get(*args, **kwargs):
     class MockedGetResponse:
         def __init__(self, headers, status_code):
-            self.headers = headers
+            self.headers = structures.CaseInsensitiveDict(headers)
             self.status_code = status_code
             self.url = args[0]
 


### PR DESCRIPTION
After investigating the [issue relating to case-insensitivity](https://github.com/GoogleChrome/first-party-sets/issues/25), it was determined that this was not the source of a problem with the robots check as our code uses python's urllib library for requests, which implements a case-insensitive dictionary for request headers. 

However, it was determined that there were some issues with the current implementation of the robots check. In particular, we realized that the non-existence of a robots.txt does not prevent web-crawlers from indexing a page. Additionally, the exiting method of checking the 'X-Robots-Tag' would exclude values of the tag that ought to be valid. This PR makes corresponding changes in the code and the submission guide to fix these issues. 