### PR TITLE
Run checks on changes only

### DIFF
--- a/.github/workflows/fps-submissions-checks.yml
+++ b/.github/workflows/fps-submissions-checks.yml
@@ -32,7 +32,7 @@ jobs:
         run: pip install publicsuffix2
       - name: Content check
         id: check
-        run: python3 main/check_sites.py -i pull-request/first_party_sets.JSON --data_directory main > results.txt
+        run: python3 main/check_sites.py -i pull-request/first_party_sets.JSON --data_directory=main --with_diff=true > results.txt
       - name: Read the result
         id: read_results
         uses: andstor/file-reader-action@v1

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -93,7 +93,7 @@ class FpsCheck:
         self.error_list += load_sets_errors
         return check_sets
 
-    def has_all_rationales(self, check_sets):
+    def has_all_rationales(self):
         """Checks for the presence of all rationaleBySite elements in schema
 
         Reads the associated sites and service sites from all FpsSets, and 
@@ -103,13 +103,13 @@ class FpsCheck:
         error_list
 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            None
         Returns:
             None
         """
         for fpset in self.fps_sites['sets']:
-            sites = check_sets[fpset.get("primary")].associated_sites
-            service_sites = check_sets[fpset.get("primary")].service_sites
+            sites = fpset.get("associatedSites")
+            service_sites = fpset.get("serviceSites")
             if sites:
                 sites = sites + service_sites if service_sites else sites
             else:

--- a/check_sites.py
+++ b/check_sites.py
@@ -42,7 +42,7 @@ def main():
         if opt == '--data_directory':
             input_prefix = arg
         if opt == '--with_diff':
-            with_diff = arg.lower == "true"
+            with_diff = arg.lower() == "true"
 
     # Open and load the json of the new list
     with open(input_file) as f:
@@ -89,13 +89,14 @@ def main():
                 exit()
         old_checker = FpsCheck(old_sites, etlds, icanns)
         check_sets, _ = find_diff_sets(old_checker.load_sets(), fps_checker.load_sets())
-
     else:
         check_sets = fps_checker.load_sets()
     
+    # Run rationale check separately from check_list since it takes no argument
+    fps_checker.has_all_rationales
 
+    # Run rest of checks
     check_list = [
-        fps_checker.has_all_rationales, 
         fps_checker.check_exclusivity,
         fps_checker.find_non_https_urls, 
         fps_checker.find_invalid_eTLD_Plus1,
@@ -110,7 +111,8 @@ def main():
         try:
             check(check_sets)
         except Exception as inst:
-            error_texts.append(inst)
+            error_texts.append("Error while processing" + check + 
+                               "\nError was: " + inst)
     # This message allows us to check the succes of our action
     if fps_checker.error_list or error_texts:
         for checker_error in fps_checker.error_list:

--- a/check_sites.py
+++ b/check_sites.py
@@ -89,8 +89,11 @@ def main():
                 exit()
         old_checker = FpsCheck(old_sites, etlds, icanns)
         check_sets, _ = find_diff_sets(old_checker.load_sets(), fps_checker.load_sets())
+        # TODO: add variable and check for subtracted_sets in case of user 
+        # removing old set from the list
     else:
         check_sets = fps_checker.load_sets()
+
     
     # Run rationale check separately from check_list since it takes no argument
     fps_checker.has_all_rationales


### PR DESCRIPTION
Currently, the checks in this repo are run on all First-Party Set entries when the workflow is triggered. This creates cases where users who are trying to enter their First-Party Set to the list will have the workflow fail due to mistakes/lack of maintenance for an older set that they do not own. With this change, when the workflow is called with "with_diff=true", the checks will only be run on sets that have been added to the list or modified. 