### PR TITLE
change com exception in find_invalid_alias_eSLDs to look at TLD only

### DIFF
--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -431,24 +431,24 @@ class FpsCheck:
                         "primary, associated site, or service site " +
                         "within the firsty pary set for " + primary)
                 # check the validity of the aliases
-                aliased_domain, aliased_etld = (aliased_site.split(".")[0],
+                aliased_eSLD, aliased_tld = (aliased_site.split(".")[0],
                                                 aliased_site.split(".")[-1])
-                if aliased_etld in self.icanns:
+                if aliased_tld in self.icanns:
                     icann_check = self.icanns.union({"com"})
                 else:
                     icann_check = self.icanns
-                plus1s = [(site, site.split(".")[0], site.split(".")[-1])
+                variants = [(site, site.split(".")[0], site.split(".")[-1])
                             for site in curr_set.ccTLDs[aliased_site]]
-                for eSLD in plus1s:
-                    if eSLD[1] != aliased_domain:
+                for site, eSLD, tld in variants:
+                    if eSLD != aliased_eSLD:
                         self.error_list.append(
                             "The following top level domain must match: " 
                             + aliased_site + ", but is instead: " 
-                            + eSLD[0])
-                    if eSLD[2] not in icann_check:
+                            + site)
+                    if tld not in icann_check:
                         self.error_list.append(
-                            "The provided country code: " + eSLD[2] + 
-                            ", in: " + eSLD[0] + 
+                            "The provided country code: " + tld + 
+                            ", in: " + site + 
                             " is not a ICANN registered country code")
 
     def find_robots_txt(self, check_sets):

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -409,34 +409,35 @@ class FpsCheck:
         """Checks that eSLDs match their alias, and that country codes are 
         members of icann
         Reads the ccTLDs and makes sure that they match their equivalent sites,
-        and that they're domains are part of ICANNS list of country codes.
-        If either of these is not the case, appends an error to the error_list
+        and that their eTLDs are part of ICANN's list of country codes.
+        If either of these is not the case, appends an error to the error_list.
+        Note: A site may list a variant with "com" as its eTLD IFF the site 
+        being aliased has an eTLD on ICANN's list of countrycodes. 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            check_sets: Dict[string, FpsSet]
         Returns:
             None
         """
         for primary in check_sets:
             curr_set = check_sets[primary]
             if curr_set.ccTLDs:
+                # This will be more elegant when the default variables are set to []
+                sites = set([primary] + 
+                            (curr_set.associated_sites if curr_set.associated_sites else []) + 
+                            (curr_set.service_sites if curr_set.service_sites else [])
+                            )
                 for aliased_site in curr_set.ccTLDs:
                     # first check if the aliased site is actually anywhere else
                     # in the fps
-                    if aliased_site != primary:
-                        if curr_set.associated_sites:
-                            sites = curr_set.associated_sites 
-                        else:
-                            sites = []
-                        if curr_set.service_sites:
-                            sites += curr_set.service_sites
-                        if aliased_site not in sites:
-                            self.error_list.append(
-                                "The aliased site " + aliased_site + 
-                                " contained within the ccTLDs must be a " +
-                                "primary, associated site, or service site " +
-                                "within the firsty pary set for " + primary)
+                    if aliased_site not in sites:
+                        self.error_list.append(
+                            "The aliased site " + aliased_site + 
+                            " contained within the ccTLDs must be a " +
+                            "primary, associated site, or service site " +
+                            "within the firsty pary set for " + primary)
                     # check the validity of the aliases
-                    aliased_domain, aliased_tld = aliased_site.split(".", 1)
+                    aliased_domain, aliased_tld = (aliased_site.split(".")[0],
+                                                   aliased_site.split(".")[-1])
                     if aliased_tld in self.icanns:
                         icann_check = self.icanns.union({"com"})
                     else:

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -75,7 +75,7 @@ class FpsCheck:
         Args:
             None
         Returns:
-            a dictionary of string->FpsSet
+            Dict[string, FpsSet]
         """
         check_sets = {}
         load_sets_errors = []
@@ -103,7 +103,7 @@ class FpsCheck:
         error_list
 
         Args:
-            None
+            Dict[string, FpsSet]
         Returns:
             None
         """
@@ -131,7 +131,7 @@ class FpsCheck:
         added to the error_list.
 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            check_sets: Dict[string, FpsSet]
         Returns:
             None
         """
@@ -194,7 +194,7 @@ class FpsCheck:
         and appends errors to the error list for any that return false
 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            check_sets: Dict[string, FpsSet]
         Returns:
             None
         """
@@ -252,7 +252,7 @@ class FpsCheck:
         and appends errors to the error list for any that return false
 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            check_sets: Dict[string, FpsSet]
         Returns:
             None
         """
@@ -348,7 +348,7 @@ class FpsCheck:
         format, or its contents do no match what is expected.
 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            check_sets: Dict[string, FpsSet]
         Returns:
             None
         """
@@ -424,7 +424,7 @@ class FpsCheck:
             for aliased_site in curr_set.ccTLDs:
                 # first check if the aliased site is actually anywhere else
                 # in the fps
-                if not curr_set.includes(aliased_site):
+                if not curr_set.includes(aliased_site, False):
                     self.error_list.append(
                         "The aliased site " + aliased_site + 
                         " contained within the ccTLDs must be a " +
@@ -463,7 +463,7 @@ class FpsCheck:
         to the error list.
 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            check_sets: Dict[string, FpsSet]
         Returns:
             None
         """
@@ -507,7 +507,7 @@ class FpsCheck:
         does not cause a timeout error. 
 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            check_sets: Dict[string, FpsSet]
         Returns:
             None
         """
@@ -542,7 +542,7 @@ class FpsCheck:
         error. 
 
         Args:
-            check_sets: a dictionary of primary->FpsSet
+            check_sets: Dict[string, FpsSet]
         Returns:
             None
         """

--- a/FpsSet.py
+++ b/FpsSet.py
@@ -34,6 +34,7 @@ class FpsSet:
                                      'primary': primary,
                                      'associatedSites': associated_sites, 
                                      'serviceSites': service_sites}
+    
     def __eq__(self, obj):
       if isinstance(obj, FpsSet) and self.primary == obj.primary:
         if self.ccTLDs == obj.ccTLDs:
@@ -41,3 +42,13 @@ class FpsSet:
             if self.service_sites == obj.service_sites:
               return True
       return False
+    
+    def includes(self, domain, with_ccTLDs=False):
+       sites = set([self.primary, 
+                        *(self.associated_sites if self.associated_sites else []),
+                        *(self.service_sites if self.service_sites else []),
+                        ])
+       if with_ccTLDs:
+          for _, aliased_sites in self.ccTLDs.items():
+             sites = sites.union(aliased_sites)
+       return domain in sites

--- a/FpsSet.py
+++ b/FpsSet.py
@@ -43,12 +43,11 @@ class FpsSet:
               return True
       return False
     
-    def includes(self, domain, with_ccTLDs=False):
-       sites = set([self.primary, 
-                        *(self.associated_sites if self.associated_sites else []),
-                        *(self.service_sites if self.service_sites else []),
-                        ])
+    def includes(self, domain, with_ccTLDs=True):
+       if (self.primary == domain or
+                   domain in (self.associated_sites or []) or
+                   domain in (self.service_sites or [])):
+           return True
        if with_ccTLDs:
-          for _, aliased_sites in self.ccTLDs.items():
-             sites = sites.union(aliased_sites)
-       return domain in sites
+           return domain in (variant for variant in self.ccTLDs.values())
+       return False

--- a/FpsSet.py
+++ b/FpsSet.py
@@ -49,5 +49,5 @@ class FpsSet:
                    domain in (self.service_sites or [])):
            return True
        if with_ccTLDs:
-           return domain in (variant for variant in self.ccTLDs.values())
+           return domain in (variant for variant_list in self.ccTLDs.values() for variant in variant_list)
        return False

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -136,6 +136,34 @@ class TestFpsSetEqual(unittest.TestCase):
         fps_2.service_sites = ["https://service2.com"]
         self.assertNotEqual(fps_1, fps_2)
 
+class TestFpsIncludes(unittest.TestCase):
+    def test_primary_case(self):
+        fps = FpsSet(ccTLDs={
+                        "https://primary.com": "https://primary.ca"
+                    }, 
+                    primary="https://primary.com")
+        self.assertTrue(fps.includes("https://primary.com"))
+        self.assertFalse(fps.includes("https://primary2.com"))
+
+    def test_associated_case(self):
+        fps = FpsSet(
+                    ccTLDs={},
+                    primary="https://primary.com",
+                    associated_sites= ["https://associated1.com", "https://associated2.com"])
+        self.assertTrue(fps.includes("https://associated1.com"))
+        self.assertTrue(fps.includes("https://associated2.com"))
+        self.assertFalse(fps.includes("https://associated3.com"))
+    
+    def test_cctld_case(self):
+        fps = FpsSet(ccTLDs={
+                        "https://primary.com": "https://primary.ca"
+                    }, 
+                    primary="https://primary.com")
+
+        self.assertTrue(fps.includes("https://primary.ca"))
+        self.assertFalse(fps.includes("https://primary.ca", with_ccTLDs=False))
+        
+
 class TestLoadSets(unittest.TestCase):
     def test_collision_case(self):
         json_dict = {
@@ -296,7 +324,6 @@ class TestCheckExclusivity(unittest.TestCase):
                     service_sites=["https://service1.com"]),
                     
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
          ["These service sites are already registered in another"
                         + " first party set: {'https://service1.com'}"])
@@ -335,7 +362,6 @@ class TestCheckExclusivity(unittest.TestCase):
                     service_sites=["https://service2.com"]),
                     
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
          ["This primary is already registered in another"
                         + " first party set: https://primary2.com"])
@@ -374,7 +400,6 @@ class TestCheckExclusivity(unittest.TestCase):
                     service_sites=["https://service2.com"]),
                     
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
     
 class TestFindNonHttps(unittest.TestCase):
@@ -401,7 +426,6 @@ class TestFindNonHttps(unittest.TestCase):
                     associated_sites=["https://associated1.com"], 
                     service_sites=["https://service1.com"])         
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
          ["The provided primary site does not begin with https:// " +
          "primary.com"])
@@ -435,7 +459,6 @@ class TestFindNonHttps(unittest.TestCase):
                         "https://primary.com": ["primary.ca"]
                     })         
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
          ["The provided alias site does not begin with" +
                                 " https:// primary.ca"])
@@ -469,7 +492,6 @@ class TestFindNonHttps(unittest.TestCase):
                         "primary.com": ["primary.ca"]
                     })         
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
          [
         "The provided primary site does not begin with https:// primary.com", 
@@ -504,7 +526,6 @@ class TestFindInvalidETLD(unittest.TestCase):
                     associated_sites=["https://associated1.com"], 
                     service_sites=["https://service1.com"])         
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
          ["The provided primary site does not have an eTLD in the" +
                     " Public suffix list: https://primary.c2om"])
@@ -539,7 +560,6 @@ class TestFindInvalidETLD(unittest.TestCase):
                         "https://primary.com": ["https://primary.c2om"]
                     })         
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
          ["The provided aliased site does not have an eTLD in the" +
                     " Public suffix list: https://primary.c2om"])
@@ -574,7 +594,6 @@ class TestFindInvalidETLD(unittest.TestCase):
                         "https://primary.c2om": ["https://primary.c2om"]
                     })         
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
          ["The provided primary site does not have an eTLD in the" +
                     " Public suffix list: https://primary.c2om",
@@ -614,7 +633,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                     }
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The following top level domain " + 
         "must match: https://primary.com, but is instead: "+
         "https://primary2.ca"])
@@ -645,7 +663,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                     }
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The provided country code: gov, "+
             "in: https://primary.gov is not a ICANN registered country code"])
                 
@@ -675,7 +692,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                     }
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The provided country code: com, "+
             "in: https://primary.com is not a ICANN registered country code"])
                 
@@ -718,7 +734,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                     }
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
     
     def test_invalid_associated_alias(self):
@@ -749,7 +764,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                     }
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The provided country code: gov, "+
             "in: https://associated.gov is not a ICANN registered country code"])
         
@@ -781,7 +795,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                     }
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
     
     def test_expected_esld(self):
@@ -810,7 +823,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                     }
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
 
 class TestFindDiff(unittest.TestCase):
@@ -1052,7 +1064,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The service site " +
         "https://service1.com " +
         "does not have an X-Robots-Tag in its header"])
@@ -1082,7 +1093,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The service site " +
         "https://service2.com " +
         "does not have a 'noindex' or 'none' tag in its header"])
@@ -1112,7 +1122,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
 
     @mock.patch('requests.get', side_effect=mock_get)
@@ -1140,7 +1149,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
 
     # We run a similar set of mock tests for ads.txt
@@ -1169,7 +1177,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The service site " +
         "https://service1.com has an ads.txt file, this " +
         "violates the policies for service sites"])
@@ -1199,7 +1206,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
 
     # We run a similar set of mock tests for redirect check
@@ -1228,7 +1234,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The service site " +
         "must not be an endpoint: https://service1.com"])
 
@@ -1257,7 +1262,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
 
     @mock.patch('requests.get', side_effect=mock_get)
@@ -1285,7 +1289,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
         
     # Now we test the mocked open_and_load_json to test the well-known checks
@@ -1314,7 +1317,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The following member(s) of " +
         "associatedSites were not present in both the changelist and " + 
         ".well-known/first-party-set.json file: ['https://expected-associated.com'"
@@ -1345,7 +1347,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The following member(s) of " +
         "primary were not present in both the changelist and " + 
         ".well-known/first-party-set.json file: ['https://primary2.com'"
@@ -1376,7 +1377,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, ["The listed associated site "
                 + "did not have https://primary3.com listed as its primary: " 
                 + "https://associated2.com"])
@@ -1406,7 +1406,6 @@ class MockTestsClass(unittest.TestCase):
                     ccTLDs=None
                     )
         }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])
 
 if __name__ == '__main__':

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -100,11 +100,11 @@ class TestValidateSchema(unittest.TestCase):
 class TestFpsSetEqual(unittest.TestCase):
     def test_equal_case(self):
         fps_1 = FpsSet(ccTLDs={
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca"]
                     }, 
                     primary="https://primary.com")
         fps_2 = FpsSet(ccTLDs={
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca"]
                     }, 
                     primary="https://primary.com")
         self.assertIsNot(fps_1, fps_2)
@@ -113,16 +113,16 @@ class TestFpsSetEqual(unittest.TestCase):
 
     def test_inequal_cases(self):
         fps_1 = FpsSet(ccTLDs={
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca"]
                     }, 
                     primary="https://primary.com")
         fps_2 = FpsSet(ccTLDs={
-                        "https://primary.com": "https://primary.co.uk"
+                        "https://primary.com": ["https://primary.co.uk"]
                     }, 
                     primary="https://primary.com")
         self.assertNotEqual(fps_1, fps_2)
 
-        fps_2.ccTLDs = {"https://primary.com": "https://primary.ca"}
+        fps_2.ccTLDs = {"https://primary.com": ["https://primary.ca"]}
         self.assertEqual(fps_1, fps_2)
 
         fps_1.associated_sites = ["https://associated1.com"]
@@ -139,7 +139,7 @@ class TestFpsSetEqual(unittest.TestCase):
 class TestFpsIncludes(unittest.TestCase):
     def test_primary_case(self):
         fps = FpsSet(ccTLDs={
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca"]
                     }, 
                     primary="https://primary.com")
         self.assertTrue(fps.includes("https://primary.com"))
@@ -156,7 +156,7 @@ class TestFpsIncludes(unittest.TestCase):
     
     def test_cctld_case(self):
         fps = FpsSet(ccTLDs={
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca", "https://primary.co.uk"]
                     }, 
                     primary="https://primary.com")
 
@@ -172,13 +172,13 @@ class TestLoadSets(unittest.TestCase):
                 {
                     "primary": "https://primary.com",
                     "ccTLDs": {
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca"]
                     }
                 },
                 {
                     "primary": "https://primary.com",
                     "ccTLDs": {
-                        "https://primary.com": "https://primary.co.uk"
+                        "https://primary.com": ["https://primary.co.uk"]
                     }
                 }
             ]
@@ -189,7 +189,7 @@ class TestLoadSets(unittest.TestCase):
         loaded_sets = fp.load_sets()
         expected_sets = {
             'https://primary.com': FpsSet(ccTLDs={
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca"]
                     }, 
                     primary="https://primary.com")
         }
@@ -204,13 +204,13 @@ class TestLoadSets(unittest.TestCase):
                 {
                     "primary": "https://primary.com",
                     "ccTLDs": {
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca"]
                     }
                 },
                 {
                     "primary": "https://primary2.com",
                     "ccTLDs": {
-                        "https://primary2.com": "https://primary2.co.uk"
+                        "https://primary2.com": ["https://primary2.co.uk"]
                     }
                 }
             ]
@@ -221,11 +221,11 @@ class TestLoadSets(unittest.TestCase):
         loaded_sets = fp.load_sets()
         expected_sets = {
             'https://primary.com': FpsSet(ccTLDs={
-                        "https://primary.com": "https://primary.ca"
+                        "https://primary.com": ["https://primary.ca"]
                     }, 
                     primary="https://primary.com"),
             'https://primary2.com': FpsSet(ccTLDs={
-                        "https://primary2.com": "https://primary2.co.uk"
+                        "https://primary2.com": ["https://primary2.co.uk"]
                     }, 
                     primary="https://primary2.com")
         }
@@ -250,13 +250,6 @@ class TestHasRationales(unittest.TestCase):
                        icanns=set())
         loaded_sets = fp.load_sets()
         fp.has_all_rationales(loaded_sets)
-        expected_sets = {
-            'https://primary.com': FpsSet(ccTLDs= None,
-                    primary="https://primary.com", 
-                    associated_sites=["https://associated1.com"], 
-                    service_sites=["https://service1.com"])
-        }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, 
         ["There is no provided rationale for https://associated1.com", 
         "There is no provided rationale for https://service1.com"])
@@ -280,13 +273,6 @@ class TestHasRationales(unittest.TestCase):
                       etlds=None,
                        icanns=set())
         loaded_sets = fp.load_sets()
-        expected_sets = {
-            'https://primary.com': FpsSet(ccTLDs=None, 
-                    primary="https://primary.com", 
-                    associated_sites=["https://associated1.com"], 
-                    service_sites=["https://service1.com"])
-        }
-        self.assertEqual(loaded_sets, expected_sets)
         self.assertEqual(fp.error_list, [])  
 
 class TestCheckExclusivity(unittest.TestCase):
@@ -313,17 +299,6 @@ class TestCheckExclusivity(unittest.TestCase):
                        icanns=set())
         loaded_sets = fp.load_sets()
         fp.check_exclusivity(loaded_sets)
-        expected_sets = {
-            'https://primary.com': FpsSet(ccTLDs= None,
-                    primary="https://primary.com", 
-                    associated_sites=["https://associated1.com"], 
-                    service_sites=["https://service1.com"]),
-            'https://primary2.com': FpsSet(ccTLDs= None,
-                    primary="https://primary2.com", 
-                    associated_sites=["https://associated2.com"], 
-                    service_sites=["https://service1.com"]),
-                    
-        }
         self.assertEqual(fp.error_list, 
          ["These service sites are already registered in another"
                         + " first party set: {'https://service1.com'}"])
@@ -351,17 +326,6 @@ class TestCheckExclusivity(unittest.TestCase):
                        icanns=set())
         loaded_sets = fp.load_sets()
         fp.check_exclusivity(loaded_sets)
-        expected_sets = {
-            'https://primary.com': FpsSet(ccTLDs= None,
-                    primary="https://primary.com", 
-                    associated_sites=["https://primary2.com"], 
-                    service_sites=["https://service1.com"]),
-            'https://primary2.com': FpsSet(ccTLDs= None,
-                    primary="https://primary2.com", 
-                    associated_sites=["https://associated2.com"], 
-                    service_sites=["https://service2.com"]),
-                    
-        }
         self.assertEqual(fp.error_list, 
          ["This primary is already registered in another"
                         + " first party set: https://primary2.com"])
@@ -389,17 +353,6 @@ class TestCheckExclusivity(unittest.TestCase):
                        icanns=set())
         loaded_sets = fp.load_sets()
         fp.check_exclusivity(loaded_sets)
-        expected_sets = {
-            'https://primary.com': FpsSet(ccTLDs= None,
-                    primary="https://primary.com", 
-                    associated_sites=["https://associated1.com"], 
-                    service_sites=["https://service1.com"]),
-            'https://primary2.com': FpsSet(ccTLDs= None,
-                    primary="https://primary2.com", 
-                    associated_sites=["https://associated2.com"], 
-                    service_sites=["https://service2.com"]),
-                    
-        }
         self.assertEqual(fp.error_list, [])
     
 class TestFindNonHttps(unittest.TestCase):
@@ -420,12 +373,6 @@ class TestFindNonHttps(unittest.TestCase):
                        icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_non_https_urls(loaded_sets)
-        expected_sets = {
-            'primary.com': FpsSet(ccTLDs= None,
-                    primary="primary.com", 
-                    associated_sites=["https://associated1.com"], 
-                    service_sites=["https://service1.com"])         
-        }
         self.assertEqual(fp.error_list, 
          ["The provided primary site does not begin with https:// " +
          "primary.com"])
@@ -450,15 +397,6 @@ class TestFindNonHttps(unittest.TestCase):
                        icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_non_https_urls(loaded_sets)
-        expected_sets = {
-            'https://primary.com': FpsSet(
-                    primary="https://primary.com", 
-                    associated_sites=["https://associated1.com"], 
-                    service_sites=["https://service1.com"],
-                    ccTLDs={
-                        "https://primary.com": ["primary.ca"]
-                    })         
-        }
         self.assertEqual(fp.error_list, 
          ["The provided alias site does not begin with" +
                                 " https:// primary.ca"])
@@ -483,15 +421,6 @@ class TestFindNonHttps(unittest.TestCase):
                        icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_non_https_urls(loaded_sets)
-        expected_sets = {
-            'primary.com': FpsSet(
-                    primary="primary.com", 
-                    associated_sites=["associated1.com"], 
-                    service_sites=["service1.com"],
-                    ccTLDs={
-                        "primary.com": ["primary.ca"]
-                    })         
-        }
         self.assertEqual(fp.error_list, 
          [
         "The provided primary site does not begin with https:// primary.com", 
@@ -520,12 +449,6 @@ class TestFindInvalidETLD(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_eTLD_Plus1(loaded_sets)
-        expected_sets = {
-            'https://primary.c2om': FpsSet(ccTLDs= None,
-                    primary="https://primary.c2om", 
-                    associated_sites=["https://associated1.com"], 
-                    service_sites=["https://service1.com"])         
-        }
         self.assertEqual(fp.error_list, 
          ["The provided primary site does not have an eTLD in the" +
                     " Public suffix list: https://primary.c2om"])
@@ -551,15 +474,6 @@ class TestFindInvalidETLD(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_eTLD_Plus1(loaded_sets)
-        expected_sets = {
-            'https://primary.com': FpsSet(
-                    primary="https://primary.com", 
-                    associated_sites=["https://associated1.com"], 
-                    service_sites=["https://service1.com"],
-                    ccTLDs={
-                        "https://primary.com": ["https://primary.c2om"]
-                    })         
-        }
         self.assertEqual(fp.error_list, 
          ["The provided aliased site does not have an eTLD in the" +
                     " Public suffix list: https://primary.c2om"])
@@ -585,15 +499,6 @@ class TestFindInvalidETLD(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_eTLD_Plus1(loaded_sets)
-        expected_sets = {
-            'https://primary.c2om': FpsSet(
-                    primary="https://primary.c2om", 
-                    associated_sites=["https://associated1.c2om"], 
-                    service_sites=["https://service1.c2om"],
-                    ccTLDs={
-                        "https://primary.c2om": ["https://primary.c2om"]
-                    })         
-        }
         self.assertEqual(fp.error_list, 
          ["The provided primary site does not have an eTLD in the" +
                     " Public suffix list: https://primary.c2om",
@@ -624,15 +529,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                      icanns=set(["ca"]))
         loaded_sets = fp.load_sets()
         fp.find_invalid_alias_eSLDs(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    ccTLDs={
-                        "https://primary.com": ["https://primary2.ca"]
-                    }
-                    )
-        }
         self.assertEqual(fp.error_list, ["The following top level domain " + 
         "must match: https://primary.com, but is instead: "+
         "https://primary2.ca"])
@@ -654,15 +550,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                      icanns=set(["ca"]))
         loaded_sets = fp.load_sets()
         fp.find_invalid_alias_eSLDs(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    ccTLDs={
-                        "https://primary.com": ["https://primary.gov"]
-                    }
-                    )
-        }
         self.assertEqual(fp.error_list, ["The provided country code: gov, "+
             "in: https://primary.gov is not a ICANN registered country code"])
                 
@@ -683,15 +570,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                      icanns=set(["ca"]))
         loaded_sets = fp.load_sets()
         fp.find_invalid_alias_eSLDs(loaded_sets)
-        expected_sets = {
-            'https://primary.edu': 
-            FpsSet(
-                    primary="https://primary.edu",
-                    ccTLDs={
-                        "https://primary.edu": ["https://primary.com"]
-                    }
-                    )
-        }
         self.assertEqual(fp.error_list, ["The provided country code: com, "+
             "in: https://primary.com is not a ICANN registered country code"])
                 
@@ -718,22 +596,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                      icanns=set(["ca", "uk"]))
         loaded_sets = fp.load_sets()
         fp.find_invalid_alias_eSLDs(loaded_sets)
-        expected_sets = {
-            'https://primary.ca': 
-            FpsSet(
-                    primary="https://primary.ca",
-                    ccTLDs={
-                        "https://primary.ca": ["https://primary.com"]
-                    }
-                    ),
-            'https://primary2.co.uk': 
-            FpsSet(
-                    primary="https://primary2.co.uk",
-                    ccTLDs={
-                        "https://primary2.co.uk": ["https://primary2.com"]
-                    }
-                    )
-        }
         self.assertEqual(fp.error_list, [])
     
     def test_invalid_associated_alias(self):
@@ -754,16 +616,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                      icanns=set(["ca"]))
         loaded_sets = fp.load_sets()
         fp.find_invalid_alias_eSLDs(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    associated_sites=["https://associated.com"],
-                    ccTLDs={
-                        "https://associated.com": ["https://associated.gov"]
-                    }
-                    )
-        }
         self.assertEqual(fp.error_list, ["The provided country code: gov, "+
             "in: https://associated.gov is not a ICANN registered country code"])
         
@@ -785,16 +637,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                      icanns=set(["ca"]))
         loaded_sets = fp.load_sets()
         fp.find_invalid_alias_eSLDs(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    associated_sites=["https://associated.com"],
-                    ccTLDs={
-                        "https://associated.com": ["https://associated.ca"]
-                    }
-                    )
-        }
         self.assertEqual(fp.error_list, [])
     
     def test_expected_esld(self):
@@ -814,15 +656,6 @@ class TestFindInvalidESLDs(unittest.TestCase):
                      icanns=set(["ca"]))
         loaded_sets = fp.load_sets()
         fp.find_invalid_alias_eSLDs(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    ccTLDs={
-                        "https://primary.com": ["https://primary.ca"]
-                    }
-                    )
-        }
         self.assertEqual(fp.error_list, [])
 
 class TestFindDiff(unittest.TestCase):
@@ -1056,14 +889,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_robots_txt(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://service1.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, ["The service site " +
         "https://service1.com " +
         "does not have an X-Robots-Tag in its header"])
@@ -1085,14 +910,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_robots_txt(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://service2.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, ["The service site " +
         "https://service2.com " +
         "does not have a 'noindex' or 'none' tag in its header"])
@@ -1114,14 +931,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_robots_txt(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://service3.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, [])
 
     @mock.patch('requests.get', side_effect=mock_get)
@@ -1141,14 +950,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_robots_txt(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://service4.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, [])
 
     # We run a similar set of mock tests for ads.txt
@@ -1169,14 +970,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_ads_txt(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://service1.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, ["The service site " +
         "https://service1.com has an ads.txt file, this " +
         "violates the policies for service sites"])
@@ -1198,14 +991,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_ads_txt(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://service5.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, [])
 
     # We run a similar set of mock tests for redirect check
@@ -1226,14 +1011,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.check_for_service_redirect(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://service1.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, ["The service site " +
         "must not be an endpoint: https://service1.com"])
 
@@ -1254,14 +1031,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.check_for_service_redirect(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://service6.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, [])
 
     @mock.patch('requests.get', side_effect=mock_get)
@@ -1281,14 +1050,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.check_for_service_redirect(loaded_sets)
-        expected_sets = {
-            'https://primary.com': 
-            FpsSet(
-                    primary="https://primary.com",
-                    service_sites=["https://no-such-service.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, [])
         
     # Now we test the mocked open_and_load_json to test the well-known checks
@@ -1309,14 +1070,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
-        expected_sets = {
-            'https://primary1.com': 
-            FpsSet(
-                    primary="https://primary1.com", 
-                    associated_sites=["https://expected-associated.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, ["The following member(s) of " +
         "associatedSites were not present in both the changelist and " + 
         ".well-known/first-party-set.json file: ['https://expected-associated.com'"
@@ -1339,14 +1092,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
-        expected_sets = {
-            'https://primary2.com': 
-            FpsSet(
-                    primary="https://primary2.com", 
-                    associated_sites=["https://associated1.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, ["The following member(s) of " +
         "primary were not present in both the changelist and " + 
         ".well-known/first-party-set.json file: ['https://primary2.com'"
@@ -1369,14 +1114,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
-        expected_sets = {
-            'https://primary3.com': 
-            FpsSet(
-                    primary="https://primary3.com", 
-                    associated_sites=["https://associated2.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, ["The listed associated site "
                 + "did not have https://primary3.com listed as its primary: " 
                 + "https://associated2.com"])
@@ -1398,14 +1135,6 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
-        expected_sets = {
-            'https://primary4.com': 
-            FpsSet(
-                    primary="https://primary4.com", 
-                    associated_sites=["https://associated3.com"],
-                    ccTLDs=None
-                    )
-        }
         self.assertEqual(fp.error_list, [])
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `com` exception added to `find_invalid_alias_eSLDs` mistakenly looked at the entire eTLD of the aliased domain, rather than the just the TLD, and checked for its presence in the ICANN list of country code top level domains. Sites that had country code TLDs but with eTLDs not on the list were thus inadvertently excluded from this exception. This meant that `example.ca` could have the alias `example.com` listed in its ccTLDs, but `example.co.uk` could not. This should be amended so that the check looks at just the TLDs when making the exceptions, creating the intended behavior in the check. 