### PR TITLE
Account for multi-level domains in etld plus 1 check

### DIFF
--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -243,7 +243,9 @@ class FpsCheck:
         Returns:
             boolean with truth value dependent on value of get_public_suffix
         """
-        return self.etlds.get_public_suffix(site, strict=True) is not None
+        ps = self.etlds.get_public_suffix(site, strict=True)
+        return (ps is not None and ps == site)
+    
 
     def find_invalid_eTLD_Plus1(self, check_sets):
         """Checks if all domains are etld+1 compliant
@@ -260,36 +262,34 @@ class FpsCheck:
             # Apply to the primary
             if not self.is_eTLD_Plus1(primary):
                 self.error_list.append(
-                    "The provided primary site does not have an eTLD in the" +
-                    " Public suffix list: " + primary)
+                    "The provided primary site is not an eTLD+1: " +
+                    primary)
             # Apply to the country codes
             if check_sets[primary].ccTLDs:
                 for alias in check_sets[primary].ccTLDs:
                     if not self.is_eTLD_Plus1(alias):
                         self.error_list.append(
-                            "The provided alias does not have an eTLD in the "
-                            + "Public suffix list: " + alias)
+                            "The provided alias is not an eTLD+1: " +
+                            alias)
                     for aliased_site in check_sets[primary].ccTLDs[alias]:
                         if not self.is_eTLD_Plus1(aliased_site):
                             self.error_list.append(
-                                "The provided aliased site does not have an "
-                                + "eTLD in the Public suffix list: " + 
-                                aliased_site)
+                                "The provided aliased site is not an eTLD+1: " 
+                                + aliased_site)
             # Apply to associated sites
             if check_sets[primary].associated_sites:
                 for associated_site in check_sets[primary].associated_sites:
                     if not self.is_eTLD_Plus1(associated_site):
                         self.error_list.append(
-                            "The provided associated site does not have an " +
-                            "eTLD in the Public suffix list: " + 
+                            "The provided associated site is not an eTLD+1: " +
                             associated_site)
             # Apply to service sites
             if check_sets[primary].service_sites:
                 for service_site in check_sets[primary].service_sites:
                     if not self.is_eTLD_Plus1(service_site):
                         self.error_list.append(
-                            "The provided service site does not have an eTLD " 
-                            + "in the Public suffix list: " + service_site)
+                            "The provided service site is not an eTLD+1: " + 
+                            service_site)
 
     def open_and_load_json(self, url):
         """Calls urlopen and returns json from a site

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -244,10 +244,10 @@ class FpsCheck:
             boolean with truth value dependent on value of get_public_suffix
         """
         assert site is not None
-        site = site.lstrip("https://")
-        is_etld_plus1 = self.etlds.get_public_suffix(site, strict=True) == site
-        is_not_etld = self.etlds.get_tld(site, strict=True) != site
-        return is_etld_plus1 and is_not_etld
+        site = site.replace("https://", "", 1)
+        has_etld = self.etlds.get_sld(site, strict=True) == site
+        is_more_than_etld = self.etlds.get_tld(site, strict=True) != site
+        return has_etld and is_more_than_etld
     
 
     def find_invalid_eTLD_Plus1(self, check_sets):

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -243,8 +243,11 @@ class FpsCheck:
         Returns:
             boolean with truth value dependent on value of get_public_suffix
         """
-        ps = self.etlds.get_public_suffix(site, strict=True)
-        return (ps is not None and ps == site)
+        assert site is not None
+        site = site.replace("https://", "")
+        is_etld_plus1 = self.etlds.get_public_suffix(site, strict=True) == site
+        is_not_etld = self.etlds.get_tld(site, strict=True) != site
+        return is_etld_plus1 and is_not_etld
     
 
     def find_invalid_eTLD_Plus1(self, check_sets):

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -245,9 +245,9 @@ class FpsCheck:
         """
         assert site is not None
         site = site.removeprefix("https://")
-        is_etldp1 = self.etlds.get_sld(site, strict=True) == site
+        is_etldp1_or_etld = self.etlds.get_sld(site, strict=True) == site
         is_etld = self.etlds.get_tld(site, strict=True) == site
-        return is_etldp1 and not is_etld
+        return is_etldp1_or_etld and not is_etld
     
 
     def find_invalid_eTLD_Plus1(self, check_sets):

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -244,7 +244,7 @@ class FpsCheck:
             boolean with truth value dependent on value of get_public_suffix
         """
         assert site is not None
-        site = site.replace("https://", "")
+        site = site.replace("https://", "", 1)
         is_etld_plus1 = self.etlds.get_public_suffix(site, strict=True) == site
         is_not_etld = self.etlds.get_tld(site, strict=True) != site
         return is_etld_plus1 and is_not_etld

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -244,10 +244,10 @@ class FpsCheck:
             boolean with truth value dependent on value of get_public_suffix
         """
         assert site is not None
-        site = site.replace("https://", "", 1)
-        has_etld = self.etlds.get_sld(site, strict=True) == site
-        is_more_than_etld = self.etlds.get_tld(site, strict=True) != site
-        return has_etld and is_more_than_etld
+        site = site.removeprefix("https://")
+        is_etldp1 = self.etlds.get_sld(site, strict=True) == site
+        is_etld = self.etlds.get_tld(site, strict=True) == site
+        return is_etldp1 and not is_etld
     
 
     def find_invalid_eTLD_Plus1(self, check_sets):

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -244,7 +244,7 @@ class FpsCheck:
             boolean with truth value dependent on value of get_public_suffix
         """
         assert site is not None
-        site = site.replace("https://", "", 1)
+        site = site.lstrip("https://")
         is_etld_plus1 = self.etlds.get_public_suffix(site, strict=True) == site
         is_not_etld = self.etlds.get_tld(site, strict=True) != site
         return is_etld_plus1 and is_not_etld

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -450,8 +450,7 @@ class TestFindInvalidETLD(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_eTLD_Plus1(loaded_sets)
         self.assertEqual(fp.error_list, 
-         ["The provided primary site does not have an eTLD in the" +
-                    " Public suffix list: https://primary.c2om"])
+         ["The provided primary site is not an eTLD+1: https://primary.c2om"])
                 
     def test_invalid_etld_cctld(self):
         json_dict = {
@@ -475,8 +474,7 @@ class TestFindInvalidETLD(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_eTLD_Plus1(loaded_sets)
         self.assertEqual(fp.error_list, 
-         ["The provided aliased site does not have an eTLD in the" +
-                    " Public suffix list: https://primary.c2om"])
+         ["The provided aliased site is not an eTLD+1: https://primary.c2om"])
                 
     def test_multi_invalid_etlds(self):
         json_dict = {
@@ -500,16 +498,50 @@ class TestFindInvalidETLD(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_eTLD_Plus1(loaded_sets)
         self.assertEqual(fp.error_list, 
-         ["The provided primary site does not have an eTLD in the" +
-                    " Public suffix list: https://primary.c2om",
-          "The provided alias does not have an eTLD in the" +
-                    " Public suffix list: https://primary.c2om",
-          "The provided aliased site does not have an eTLD in the" +
-                    " Public suffix list: https://primary.c2om",
-          "The provided associated site does not have an eTLD in the" +
-                    " Public suffix list: https://associated1.c2om",
-          "The provided service site does not have an eTLD in the" +
-                    " Public suffix list: https://service1.c2om"])
+         ["The provided primary site is not an eTLD+1: https://primary.c2om",
+          "The provided alias is not an eTLD+1: https://primary.c2om",
+          "The provided aliased site is not an eTLD+1: https://primary.c2om",
+          "The provided associated site is not an eTLD+1: https://associated1.c2om",
+          "The provided service site is not an eTLD+1: https://service1.c2om"])
+    def test_not_etld_plus1(self):
+        json_dict = {
+            "sets":
+            [
+                {
+                    "primary": "https://subdomain.primary.com",
+                    "ccTLDs": {},
+                    "rationaleBySite": {}
+                }
+            ]
+        }
+        fp = FpsCheck(fps_sites=json_dict,
+                     etlds=PublicSuffixList(
+                        psl_file = 'effective_tld_names.dat'),
+                     icanns=set())
+        loaded_sets = fp.load_sets()
+        fp.find_invalid_eTLD_Plus1(loaded_sets)
+        self.assertEqual(fp.error_list, 
+                         ["The provided primary site is not an eTLD+1: https://subdomain.primary.com"])
+        
+    def test_valid_etld_plus1(self):
+        json_dict = {
+            "sets":
+            [
+                {
+                    "primary": "https://primary.com.ar",
+                    "ccTLDs": {},
+                    "rationaleBySite": {}
+                }
+            ]
+        }
+        fp = FpsCheck(fps_sites=json_dict,
+                     etlds=PublicSuffixList(
+                        psl_file = 'effective_tld_names.dat'),
+                     icanns=set())
+        loaded_sets = fp.load_sets()
+        fp.find_invalid_eTLD_Plus1(loaded_sets)
+        self.assertEqual(fp.error_list, 
+                         [])
         
 class TestFindInvalidESLDs(unittest.TestCase):
     def test_invalid_alias_name(self):

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -582,7 +582,7 @@ class TestFindInvalidETLD(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_eTLD_Plus1(loaded_sets)
         self.assertEqual(fp.error_list, 
-        ["The provided primary site is not an eTLD+1: https://7.bg"])
+                ["The provided primary site is not an eTLD+1: https://7.bg"])
         
 class TestFindInvalidESLDs(unittest.TestCase):
     def test_invalid_alias_name(self):

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -565,6 +565,25 @@ class TestFindInvalidETLD(unittest.TestCase):
         self.assertEqual(fp.error_list, 
                          [])
         
+    def test_just_suffix(self):
+        json_dict = {
+            "sets":
+            [
+                {
+                    "primary": "https://7.bg",
+                    "rationaleBySite": {}
+                }
+            ]
+        }
+        fp = FpsCheck(fps_sites=json_dict,
+                    etlds=PublicSuffixList(
+                        psl_file = 'effective_tld_names.dat'),
+                    icanns=set())
+        loaded_sets = fp.load_sets()
+        fp.find_invalid_eTLD_Plus1(loaded_sets)
+        self.assertEqual(fp.error_list, 
+        ["The provided primary site is not an eTLD+1: https://7.bg"])
+        
 class TestFindInvalidESLDs(unittest.TestCase):
     def test_invalid_alias_name(self):
         json_dict = {

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -430,6 +430,7 @@ class TestFindNonHttps(unittest.TestCase):
         "associated1.com",
         "The provided service site does not begin with https:// service1.com"
          ])
+        
 class TestFindInvalidETLD(unittest.TestCase):
     def test_invalid_etld_primary(self):
         json_dict = {
@@ -503,6 +504,7 @@ class TestFindInvalidETLD(unittest.TestCase):
           "The provided aliased site is not an eTLD+1: https://primary.c2om",
           "The provided associated site is not an eTLD+1: https://associated1.c2om",
           "The provided service site is not an eTLD+1: https://service1.c2om"])
+        
     def test_not_etld_plus1(self):
         json_dict = {
             "sets":
@@ -529,6 +531,26 @@ class TestFindInvalidETLD(unittest.TestCase):
             [
                 {
                     "primary": "https://primary.com.ar",
+                    "ccTLDs": {},
+                    "rationaleBySite": {}
+                }
+            ]
+        }
+        fp = FpsCheck(fps_sites=json_dict,
+                     etlds=PublicSuffixList(
+                        psl_file = 'effective_tld_names.dat'),
+                     icanns=set())
+        loaded_sets = fp.load_sets()
+        fp.find_invalid_eTLD_Plus1(loaded_sets)
+        self.assertEqual(fp.error_list, 
+                         [])
+    
+    def test_valid_tld_plus1(self):
+        json_dict = {
+            "sets":
+            [
+                {
+                    "primary": "https://primary.com",
                     "ccTLDs": {},
                     "rationaleBySite": {}
                 }


### PR DESCRIPTION
Currently, `is_eTLD_Plus1` does not run as intended - it merely confirms that domain names it is passed contain a TLD in the PSL. The function should be changed to properly confirm that the domain does contain a TLD in the PSL, and that it is ONLY that domain plus one more level. For example, `primary.com` and `primary.co.uk` should both be accepted as "com" and "co.uk" are both listed in the PSL. However, `primary.example.com` should not be accepted as "example.com" is not listed in the PSL, therefore `primary.example.com` is two levels higher than a PSL listed domain. 