### PR TITLE
Add check for subtracted sets

### DIFF
--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -425,11 +425,11 @@ class FpsCheck:
                 r = requests.get(url, timeout=10)
                 if r.status_code != 404:
                     self.error_list.append("The set associated with " + primary
-                            + " was removed from the list, but " + primary + WELL_KNOWN + 
+                            + " was removed from the list, but " + url + 
                             " does not return error 404.")
             except Exception as inst:
                 self.error_list.append("Unexpected error when accessing " +
-                                    primary + "; Received error:" + str(inst))
+                                    url + "; Received error:" + str(inst))
 
     def find_invalid_alias_eSLDs(self, check_sets):
         """Checks that eSLDs match their alias, and that country codes are 

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -19,6 +19,7 @@ from urllib.request import urlopen
 from urllib.request import Request
 from publicsuffix2 import PublicSuffixList
 
+WELL_KNOWN = "/.well-known/first-party-set.json"
 
 class FpsCheck:
 
@@ -35,7 +36,7 @@ class FpsCheck:
                 without any given check failing halfway through and not 
                 catching other issues. 
   """
-    WELLKNOWN = "/.well-known/first-party-set.json"
+    
 
     def __init__(self, fps_sites: json, etlds: PublicSuffixList, icanns: set):
         """Stores the input from canonical_sites, effective_tld_names.dat, and 
@@ -324,7 +325,7 @@ class FpsCheck:
             None
         """
         for site in site_list:
-            url = site + self.WELLKNOWN
+            url = site + WELL_KNOWN
             try:
                 json_schema = self.open_and_load_json(url)
                 if 'primary' not in json_schema.keys():
@@ -359,7 +360,7 @@ class FpsCheck:
         # Check the schema to ensure consistency
         for primary in check_sets:
             # First we check the primary sites
-            url = primary + self.WELLKNOWN
+            url = primary + WELL_KNOWN
             # Read the well-known files and check them against the schema we 
             # have stored
             try:
@@ -419,7 +420,7 @@ class FpsCheck:
         Returns:
             None"""
         for primary in subtracted_sets:
-            url = primary + self.WELLKNOWN
+            url = primary + WELL_KNOWN
             try:
                 r = requests.get(url, timeout=10)
                 if r.status_code != 404:

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -35,6 +35,7 @@ class FpsCheck:
                 without any given check failing halfway through and not 
                 catching other issues. 
   """
+    WELLKNOWN = "/.well-known/first-party-set.json"
 
     def __init__(self, fps_sites: json, etlds: PublicSuffixList, icanns: set):
         """Stores the input from canonical_sites, effective_tld_names.dat, and 
@@ -323,7 +324,7 @@ class FpsCheck:
             None
         """
         for site in site_list:
-            url = site + "/.well-known/first-party-set.json"
+            url = site + self.WELLKNOWN
             try:
                 json_schema = self.open_and_load_json(url)
                 if 'primary' not in json_schema.keys():
@@ -358,7 +359,7 @@ class FpsCheck:
         # Check the schema to ensure consistency
         for primary in check_sets:
             # First we check the primary sites
-            url = primary + "/.well-known/first-party-set.json"
+            url = primary + self.WELLKNOWN
             # Read the well-known files and check them against the schema we 
             # have stored
             try:
@@ -418,7 +419,7 @@ class FpsCheck:
         Returns:
             None"""
         for primary in subtracted_sets:
-            url = primary + "/.well-known/first-party-set.json"
+            url = primary + self.WELLKNOWN
             try:
                 r = requests.get(url, timeout=10)
                 if r.status_code != 404:

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -425,7 +425,7 @@ class FpsCheck:
                 r = requests.get(url, timeout=10)
                 if r.status_code != 404:
                     self.error_list.append("The set associated with " + primary
-                            + " was removed from the list, but " + primary + 
+                            + " was removed from the list, but " + primary + WELL_KNOWN + 
                             " does not return error 404.")
             except Exception as inst:
                 self.error_list.append("Unexpected error when accessing " +

--- a/FpsCheck.py
+++ b/FpsCheck.py
@@ -407,6 +407,27 @@ class FpsCheck:
                 for aliased_site in check_sets[primary].ccTLDs:
                     ccTLD_sites += check_sets[primary].ccTLDs[aliased_site]
                     self.check_list_sites(primary, ccTLD_sites)
+        
+    def find_invalid_removal(self, subtracted_sets):
+        """Checks that any sets being removed were properly removed by owner
+        
+        Checks that the /.well-known page for the primary of any FPS removed
+        from the list returns an error 404.
+        Args:
+            subtracted_sets: Dict[string, FpsSet]
+        Returns:
+            None"""
+        for primary in subtracted_sets:
+            url = primary + "/.well-known/first-party-set.json"
+            try:
+                r = requests.get(url, timeout=10)
+                if r.status_code != 404:
+                    self.error_list.append("The set associated with " + primary
+                            + " was removed from the list, but " + primary + 
+                            " does not return error 404.")
+            except Exception as inst:
+                self.error_list.append("Unexpected error when accessing " +
+                                    primary + "; Received error:" + str(inst))
 
     def find_invalid_alias_eSLDs(self, check_sets):
         """Checks that eSLDs match their alias, and that country codes are 

--- a/check_sites.py
+++ b/check_sites.py
@@ -39,7 +39,7 @@ def find_diff_sets(old_sets, new_sets):
     subtracted_sets = {
         primary: old_sets[primary]
         for primary in set(old_sets) - set(new_sets)
-        if not any(fps.includes(primary) for _, fps in new_sets.items())
+        if not any(fps.includes(primary) for fps in new_sets.values())
     }
     return diff_sets, subtracted_sets
 

--- a/check_sites.py
+++ b/check_sites.py
@@ -36,9 +36,12 @@ def find_diff_sets(old_sets, new_sets):
              for primary, fps in new_sets.items()
              if fps != old_sets.get(primary)
             }
-
     subtracted_sets = {primary: old_sets[primary] for primary in set(old_sets) - set(new_sets)}
-
+    # Make sure that subtracted sets aren't just sets with changed primaries
+    for _, fps in diff_sets.items():
+        for primary in subtracted_sets:
+            if fps.includes(primary):
+                subtracted_sets -= primary
     return diff_sets, subtracted_sets
 
 
@@ -85,8 +88,16 @@ def main():
         # If the schema is invalid, we will not run any other checks
         print(inst)
         return
+    
+    # Check for exclusivity among all sets in the updated version
+    try:
+        fps_checker.check_exclusivity(fps_checker.load_sets())
+    except Exception as inst:
+            error_texts.append(inst)
+
 
     check_sets = {}
+    subtracted_sets = {}
     # If called with with_diff, we must determine the sets that are different 
     # to properly construct our check_sets
     if with_diff:   
@@ -100,16 +111,19 @@ def main():
                     "\nerror was: " + inst)
                 return
         old_checker = FpsCheck(old_sites, etlds, icanns)
-        check_sets, _ = find_diff_sets(old_checker.load_sets(), fps_checker.load_sets())
+        check_sets, subtracted_sets = find_diff_sets(old_checker.load_sets(), fps_checker.load_sets())
         # TODO: add variable and check for subtracted_sets in case of user 
         # removing old set from the list
     else:
         check_sets = fps_checker.load_sets()
 
+    # Run check on subtracted sets
+    if subtracted_sets:
+        fps_checker.find_invalid_removal(subtracted_sets)
+
     # Run rest of checks
     check_list = [
         fps_checker.has_all_rationales,
-        fps_checker.check_exclusivity,
         fps_checker.find_non_https_urls, 
         fps_checker.find_invalid_eTLD_Plus1,
         fps_checker.find_invalid_well_known, 

--- a/check_sites.py
+++ b/check_sites.py
@@ -36,12 +36,11 @@ def find_diff_sets(old_sets, new_sets):
              for primary, fps in new_sets.items()
              if fps != old_sets.get(primary)
             }
-    subtracted_sets = {primary: old_sets[primary] for primary in set(old_sets) - set(new_sets)}
-    # Make sure that subtracted sets aren't just sets with changed primaries
-    for _, fps in diff_sets.items():
-        for primary in subtracted_sets:
-            if fps.includes(primary):
-                subtracted_sets -= primary
+    subtracted_sets = {
+        primary: old_sets[primary]
+        for primary in set(old_sets) - set(new_sets)
+        if not any(fps.includes(primary) for _, fps in new_sets.items())
+    }
     return diff_sets, subtracted_sets
 
 
@@ -118,8 +117,7 @@ def main():
         check_sets = fps_checker.load_sets()
 
     # Run check on subtracted sets
-    if subtracted_sets:
-        fps_checker.find_invalid_removal(subtracted_sets)
+    fps_checker.find_invalid_removal(subtracted_sets)
 
     # Run rest of checks
     check_list = [

--- a/first_party_sets.JSON
+++ b/first_party_sets.JSON
@@ -67,16 +67,6 @@
       "rationaleBySite": {
         "https://songshare.com": "Specialized Platform for Music Smart Links"
       }
-    },
-    {
-      "contact": "alexey@landyrev.com",
-      "primary": "https://landyrev.com",
-      "associatedSites": [
-        "https://landyrev.ru"
-      ],
-      "rationaleBySite": {
-        "https://landyrev.ru": "Same publisher's website in a different region"
-      }
     }
   ]
 }

--- a/first_party_sets.JSON
+++ b/first_party_sets.JSON
@@ -67,6 +67,16 @@
       "rationaleBySite": {
         "https://songshare.com": "Specialized Platform for Music Smart Links"
       }
+    },
+    {
+      "contact": "alexey@landyrev.com",
+      "primary": "https://landyrev.com",
+      "associatedSites": [
+        "https://landyrev.ru"
+      ],
+      "rationaleBySite": {
+        "https://landyrev.ru": "Same publisher's website in a different region"
+      }
     }
   ]
 }

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -869,6 +869,34 @@ class TestFindDiff(unittest.TestCase):
         }
         self.assertEqual(find_diff_sets(old_sets, new_sets), (new_sets, {}))
 
+    def test_primary_to_member(self):
+        old_sets = {
+            'https://primary.com': 
+            FpsSet(
+                    primary="https://primary.com",
+                    ccTLDs={
+                        "https://primary.com": ["https://primary.ca"]
+                    }
+                    ),
+            'https://primary2.com':
+            FpsSet(
+                    primary="https://primary2.com",
+                    ccTLDs={
+                    }
+                    )
+        }
+        new_sets = {
+            'https://primary.com': 
+            FpsSet(
+                    primary="https://primary.com",
+                    associated_sites= ["https://primary2.com"],
+                    ccTLDs={
+                        "https://primary.com": ["https://primary.ca"]
+                    }
+                    )
+        }
+        self.assertEqual(find_diff_sets(old_sets, new_sets), (new_sets, {}))
+
 
 # This method will be used in tests below to mock get requests
 def mock_get(*args, **kwargs):

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -1171,7 +1171,8 @@ class MockTestsClass(unittest.TestCase):
         fp.find_invalid_removal(subtracted_sets)
         self.assertEqual(fp.error_list, ["The set associated with " +
                 "https://primary1.com was removed from the list, but " +
-                "https://primary1.com does not return error 404."])
+                "https://primary1.com/.well-known/first-party-set.json does " +
+                "not return error 404."])
         
     @mock.patch('requests.get', side_effect=mock_get)
     def test_find_valid_removal(self, mock_get):

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -894,6 +894,8 @@ def mock_get(*args, **kwargs):
         return mgr
     elif args[0].startswith('https://service'):
         return MockedGetResponse({},200)
+    elif args[0] == 'https://primary1.com/.well-known/first-party-set.json':
+        return MockedGetResponse({}, 200)
     
     return MockedGetResponse(None, 404)
 
@@ -1124,7 +1126,40 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.check_for_service_redirect(loaded_sets)
         self.assertEqual(fp.error_list, [])
+
+    # Now we test check_invalid_removal by checking for an error 404
+    @mock.patch('requests.get', side_effect=mock_get)
+    def test_find_invalid_removal(self, mock_get):
+        subtracted_sets = {
+            'https://primary1.com': 
+            FpsSet(
+                    primary='https://primary1.com',
+                    ccTLDs={}
+                    )
+        }
+        fp = FpsCheck(fps_sites={},
+                     etlds=None,
+                     icanns=set())
+        fp.find_invalid_removal(subtracted_sets)
+        self.assertEqual(fp.error_list, ["The set associated with " +
+                "https://primary1.com was removed from the list, but " +
+                "https://primary1.com does not return error 404."])
         
+    @mock.patch('requests.get', side_effect=mock_get)
+    def test_find_valid_removal(self, mock_get):
+        subtracted_sets = {
+            'https://primary2.com': 
+            FpsSet(
+                    primary="https://primary2.com",
+                    ccTLDs={}
+                    )
+        }
+        fp = FpsCheck(fps_sites={},
+                     etlds=None,
+                     icanns=set())
+        fp.find_invalid_removal(subtracted_sets)
+        self.assertEqual(fp.error_list, [])
+
     # Now we test the mocked open_and_load_json to test the well-known checks
     @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 
     side_effect=mock_open_and_load_json)


### PR DESCRIPTION
Currently, the workflow does not run a check for a case where a pull request removes an entire set from the list. A check should therefore be added ensuring that the well-known page for the primary of a removed set serves an error 404. This will confirm that the set was intended to be removed from the list by the owner of the affected domain.