### PR TITLE
Fix well-known check to match fields of FPS entry with JSON file

### DIFF
--- a/FpsSet.py
+++ b/FpsSet.py
@@ -26,14 +26,14 @@ class FpsSet:
     of each field to their value within the object. 
   """
     def __init__(self, ccTLDs, primary, associated_sites=[], service_sites=[]):
-        self.ccTLDs = ccTLDs
+        self.ccTLDs = {} if ccTLDs is None else ccTLDs
         self.primary = primary
-        self.associated_sites = associated_sites
-        self.service_sites = service_sites
-        self.relevant_fields_dict = {'ccTLDs': ccTLDs, 
-                                     'primary': primary,
-                                     'associatedSites': associated_sites, 
-                                     'serviceSites': service_sites}
+        self.associated_sites = [] if associated_sites is None else associated_sites
+        self.service_sites = [] if service_sites is None else service_sites
+        self.relevant_fields_dict = {'ccTLDs': self.ccTLDs, 
+                                     'primary': self.primary,
+                                     'associatedSites': self.associated_sites, 
+                                     'serviceSites': self.service_sites}
     
     def __eq__(self, obj):
       if isinstance(obj, FpsSet) and self.primary == obj.primary:

--- a/FpsSet.py
+++ b/FpsSet.py
@@ -27,7 +27,7 @@ class FpsSet:
   """
     def __init__(self, ccTLDs, primary, associated_sites=[], service_sites=[]):
         self.ccTLDs = {} if ccTLDs is None else ccTLDs
-        self.primary = primary
+        self.primary = "" if primary is None else primary
         self.associated_sites = [] if associated_sites is None else associated_sites
         self.service_sites = [] if service_sites is None else service_sites
         self.relevant_fields_dict = {'ccTLDs': self.ccTLDs, 

--- a/FpsSet.py
+++ b/FpsSet.py
@@ -25,7 +25,7 @@ class FpsSet:
     relevant_fields_dict: a dictionary mapping the JSON field equivalents
     of each field to their value within the object. 
   """
-    def __init__(self, ccTLDs, primary, associated_sites=None, service_sites=None):
+    def __init__(self, ccTLDs, primary, associated_sites=[], service_sites=[]):
         self.ccTLDs = ccTLDs
         self.primary = primary
         self.associated_sites = associated_sites

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -968,6 +968,11 @@ def mock_open_and_load_json(*args, **kwargs):
         return {
             "primary": "https://primary4.com"
         }
+    elif args[0] == 'https://primary5.com/.well-known/first-party-set.json':
+        return {
+            "primary": "https://primary5.com",
+            "unchecked": "An unchecked field"
+        }
     return {"primary":None}
 
 # Our test case class
@@ -1229,10 +1234,9 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
-        self.assertEqual(fp.error_list, ["The following member(s) of " +
-        "primary were not present in both the changelist and " + 
-        ".well-known/first-party-set.json file: ['https://primary2.com'"
-        + ", 'https://wrong-primary.com']"])
+        self.assertEqual(fp.error_list, ["The following primary was not "
+        + "present in both the changelist and .well-known/first-party-set.json"
+        + " file: ['https://primary2.com', 'https://wrong-primary.com']"])
 
     @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 
     side_effect=mock_open_and_load_json)
@@ -1273,6 +1277,7 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
         self.assertEqual(fp.error_list, [])
+
     @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 
     side_effect=mock_open_and_load_json)
     def test_absent_field(self, mock_open_and_load_json):
@@ -1292,6 +1297,7 @@ class MockTestsClass(unittest.TestCase):
         self.assertEqual(fp.error_list, ["The following member(s) of " +
         "associatedSites were not present in both the changelist and " + 
         ".well-known/first-party-set.json file: ['https://not-in-list.com']"])
+
     @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 
     side_effect=mock_open_and_load_json)
     def test_differing_fields(self, mock_open_and_load_json):
@@ -1315,6 +1321,7 @@ class MockTestsClass(unittest.TestCase):
         "The following member(s) of serviceSites were not present in both " +
          "the changelist and .well-known/first-party-set.json file: "
          + "['https://expected-associated.com']"])
+        
     @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 
     side_effect=mock_open_and_load_json)
     def test_unchecked_field(self, mock_open_and_load_json):
@@ -1336,6 +1343,23 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
         self.assertEqual(sorted(fp.error_list), [])
-
+    
+    @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 
+    side_effect=mock_open_and_load_json)
+    def test_unchecked_well_known_field(self, mock_open_and_load_json):
+        json_dict = {
+            "sets":
+            [
+                {
+                    "primary": "https://primary5.com",
+                }
+            ]
+        }
+        fp = FpsCheck(fps_sites=json_dict,
+                     etlds=None,
+                     icanns=set())
+        loaded_sets = fp.load_sets()
+        fp.find_invalid_well_known(loaded_sets)
+        self.assertEqual(sorted(fp.error_list), [])
 if __name__ == '__main__':
     unittest.main()

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -1213,7 +1213,7 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
         self.assertEqual(fp.error_list, 
-        ["Experienced a mismatch between the PR submission and the " + 
+        ["Encountered an inequality between the PR submission and the " + 
         "/.well-known/first-party-set.json file:\n\tassociatedSites was " +
         "['https://expected-associated.com'] in the PR, and " +
         "['https://not-in-list.com'] in the well-known.\n\tDiff was: " + 
@@ -1236,9 +1236,9 @@ class MockTestsClass(unittest.TestCase):
                      icanns=set())
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
-        self.assertEqual(fp.error_list, ["The following primary was not "
-        + "present in both the PR and /.well-known/first-party-set.json"
-        + " file: ['https://primary2.com', 'https://wrong-primary.com']"])
+        self.assertEqual(fp.error_list, ["The /.well-known/first-party-set.json"
+        + " set's primary (https://wrong-primary.com) did not equal the PR "
+        + "set's primary (https://primary2.com)"])
 
     @mock.patch('FpsCheck.FpsCheck.open_and_load_json', 
     side_effect=mock_open_and_load_json)
@@ -1297,7 +1297,7 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
         self.assertEqual(fp.error_list, 
-        ["Experienced a mismatch between the PR submission and the " + 
+        ["Encountered an inequality between the PR submission and the " + 
         "/.well-known/first-party-set.json file:\n\tassociatedSites was [] in "
         + "the PR, and ['https://not-in-list.com'] in the well-known.\n\tDiff "
         + "was: ['https://not-in-list.com']."])
@@ -1320,11 +1320,11 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
         self.assertEqual(sorted(fp.error_list), 
-        ["Experienced a mismatch between the PR submission and the " + 
+        ["Encountered an inequality between the PR submission and the " + 
         "/.well-known/first-party-set.json file:\n\tassociatedSites was [] in "
         + "the PR, and ['https://not-in-list.com'] in the well-known.\n\tDiff "
         + "was: ['https://not-in-list.com'].",
-        "Experienced a mismatch between the PR submission and the " 
+        "Encountered an inequality between the PR submission and the " 
         + "/.well-known/first-party-set.json file:\n\tserviceSites was " + 
         "['https://expected-associated.com'] in the PR, and [] in the " +
         "well-known.\n\tDiff was: ['https://expected-associated.com']."])
@@ -1390,12 +1390,7 @@ class MockTestsClass(unittest.TestCase):
         loaded_sets = fp.load_sets()
         fp.find_invalid_well_known(loaded_sets)
         self.assertEqual(sorted(fp.error_list), [
-            "Experienced a mismatch between the PR submission and the " +
-            "/.well-known/first-party-set.json file:\n\tccTLD key list was " +
-            "dict_keys(['https://associated3.com']) in the PR, and " +
-            "dict_keys([]) in the well-known.\n\tDiff was: " +
-            "['https://associated3.com'].",
-            "Experienced a mismatch between the PR submission and the "
+            "Encountered an inequality between the PR submission and the "
             "/.well-known/first-party-set.json file:\n\t" +
             "https://associated3.com alias list was ['https://associated3.ca']"
             + " in the PR, and [] in the well-known.\n\tDiff was: " +


### PR DESCRIPTION
Currently, if the well-known page of an FPS entry's primary contains a field that is not in the FPS entry itself, a NoneType Error will occur during the well-known check, and this will surface to the uploader when they attempt to make their PR, such as here as can be seen [here](https://github.com/GoogleChrome/first-party-sets/pull/67#issuecomment-1694200106). This error does not cause any technical issues with the FPS upload process, but it should be changed so that this case is properly caught and communicated to the uploader, allowing them to understand how their PR should be fixed in order to pass the checks and be merged. 