### PR TITLE
Fix path in unit tests to work more generally

### DIFF
--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -5,7 +5,7 @@ from publicsuffix2 import PublicSuffixList
 from unittest import mock
 from requests import structures
 
-sys.path.append('../first-party-sets')
+sys.path.append('tests/..')
 from FpsSet import FpsSet
 from FpsCheck import FpsCheck
 from check_sites import find_diff_sets

--- a/tests/fps_tests.py
+++ b/tests/fps_tests.py
@@ -5,7 +5,7 @@ from publicsuffix2 import PublicSuffixList
 from unittest import mock
 from requests import structures
 
-sys.path.append('tests/..')
+sys.path.append('.')
 from FpsSet import FpsSet
 from FpsCheck import FpsCheck
 from check_sites import find_diff_sets


### PR DESCRIPTION
Currently the argument passed to `Sys.path.append()` in `fps_tests.py` may make it difficult for developers to test locally. This PR will make it easier to for developers to run the unit tests on their local repo regardless of what they title their local directory. 