### PR TITLE
Change FPS references in Readme to RWS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
-# **First-Party Sets**
-For full instructions and guidance on how to submit a set, please read the [First-Party Sets Submission Guidelines](https://github.com/GoogleChrome/first-party-sets/blob/main/FPS-Submission_Guidelines.md).
+# **Related Website Sets**
+For full instructions and guidance on how to submit a set, please read the [Related Website Sets Submission Guidelines](https://github.com/GoogleChrome/first-party-sets/blob/main/RWS-Submission_Guidelines.md).
 
-For clarity on the First-Party Sets proposal being incubated in WICG, please 
-read the [First-Party Sets explainer](https://github.com/WICG/first-party-sets/).
+For clarity on the Related Website Sets proposal being incubated in WICG, please 
+read the [Related Website Sets explainer](https://github.com/WICG/first-party-sets/).
 
 The following is a description of the contents of this repository:
 
 
 
-* Guidance on submitting First-Party Sets: [FPS-Submission_Guidelines.md](https://github.com/GoogleChrome/first-party-sets/blob/main/FPS-Submission_Guidelines.md)
-* A JSON document of First-Party Sets: [first_party_sets.JSON](https://github.com/GoogleChrome/first-party-sets/blob/main/first_party_sets.JSON)
-* Various submission checks visible in [FpsCheck.py](https://github.com/GoogleChrome/first-party-sets/blob/main/FpsCheck.py)
-    * [FpsSet.py](https://github.com/GoogleChrome/first-party-sets/blob/main/FpsSet.py) 
-    defines an object type used by [FpsCheck.py](https://github.com/GoogleChrome/first-party-sets/blob/main/FpsCheck.py)
+* Guidance on submitting Related Website Sets: [RWS-Submission_Guidelines.md](https://github.com/GoogleChrome/first-party-sets/blob/main/RWS-Submission_Guidelines.md)
+* A JSON document of Related Website Sets: [related_website_sets.JSON](https://github.com/GoogleChrome/first-party-sets/blob/main/related_website_sets.JSON)
+* Various submission checks visible in [RwsCheck.py](https://github.com/GoogleChrome/first-party-sets/blob/main/RwsCheck.py)
+    * [RwsSet.py](https://github.com/GoogleChrome/first-party-sets/blob/main/RwsSet.py) 
+    defines an object type used by [RwsCheck.py](https://github.com/GoogleChrome/first-party-sets/blob/main/RwsCheck.py)
     * [Check_sites.py](https://github.com/GoogleChrome/first-party-sets/blob/main/check_sites.py) 
     calls a number of submission checks visible in 
-    [FpsCheck.py](https://github.com/GoogleChrome/first-party-sets/blob/main/FpsCheck.py)
-    * [tests/fps_tests.py](https://github.com/GoogleChrome/first-party-sets/blob/main/tests/fps_tests.py) 
+    [RwsCheck.py](https://github.com/GoogleChrome/first-party-sets/blob/main/RwsCheck.py)
+    * [tests/rws_tests.py](https://github.com/GoogleChrome/first-party-sets/blob/main/tests/rws_tests.py) 
     includes examples of failing set submissions and which checks 
     they will fail
 * Reference files like 


### PR DESCRIPTION
Readme.md was missed by [the renaming PR](https://github.com/GoogleChrome/first-party-sets/pull/87), so its file references are now out of date. This PR updates those references to account for the FPS to RWS change. 